### PR TITLE
Implement basic SMK dashboard modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,16 +18,20 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.540.0",
+        "qrcode": "^1.5.3",
         "react": "^19.1.1",
         "react-day-picker": "^9.9.0",
         "react-dom": "^19.1.1",
         "recharts": "^3.1.2",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss": "^4.1.12"
+        "tailwindcss": "^4.1.12",
+        "xlsx": "^0.18.5",
+        "zustand": "^4.4.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
         "@types/node": "^24.3.0",
+        "@types/qrcode": "^1.5.2",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -2444,6 +2448,16 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.5.tgz",
+      "integrity": "sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
@@ -2785,6 +2799,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2802,11 +2825,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2911,6 +2942,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001736",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001736.tgz",
@@ -2931,6 +2971,19 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2970,6 +3023,17 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2979,11 +3043,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2996,7 +3068,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -3012,6 +3083,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3190,6 +3273,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -3218,12 +3310,24 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.207",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.207.tgz",
       "integrity": "sha512-mryFrrL/GXDTmAtIVMVf+eIXM09BBPlO5IQ7lUyKmK8d+A4VpRGG+M3ofoVef6qyF8s60rJei8ymlJxjUA8Faw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -3621,6 +3725,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3643,6 +3756,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-nonce": {
@@ -3767,6 +3889,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4340,6 +4471,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4357,7 +4497,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4390,6 +4529,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -4438,6 +4586,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -4654,6 +4819,21 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -4760,6 +4940,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4790,6 +4976,44 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5254,6 +5478,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5264,12 +5512,140 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -5282,6 +5658,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "react-dom": "^19.1.1",
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.12"
+    "tailwindcss": "^4.1.12",
+    "zustand": "^4.4.1",
+    "qrcode": "^1.5.3",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -40,6 +43,7 @@
     "tw-animate-css": "^1.3.7",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "@types/qrcode": "^1.5.2"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,7 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import DashboardUtama from './components/DashboardUtama';
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <DashboardUtama />;
 }
 
-export default App
+export default App;

--- a/src/components/AbsensiQR.tsx
+++ b/src/components/AbsensiQR.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { format } from 'date-fns';
+import { Card } from './ui/card';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { useQRGenerator } from '../hooks/useQRGenerator';
+import { useEskulStore } from '../stores/eskulStore';
+
+const AbsensiQR = () => {
+  const kelasAktif = useEskulStore((s) => s.kelasAktif);
+  const absenSiswa = useEskulStore((s) => s.absenSiswa);
+  const absensiKelas = useEskulStore((s) => s.absensi[kelasAktif] || []);
+  const generate = useQRGenerator();
+  const [qr, setQr] = useState('');
+  const [nama, setNama] = useState('');
+
+  useEffect(() => {
+    if (kelasAktif) {
+      generate({
+        kelasId: kelasAktif,
+        tanggal: format(new Date(), 'yyyy-MM-dd'),
+        timestamp: Date.now(),
+        type: 'absensi',
+      }).then(setQr);
+    }
+  }, [kelasAktif, generate]);
+
+  const handleManual = () => {
+    if (!nama || !kelasAktif) return;
+    const id = Date.now().toString();
+    absenSiswa({
+      id,
+      siswaId: nama,
+      kelasId: kelasAktif,
+      tanggal: format(new Date(), 'yyyy-MM-dd'),
+      status: 'hadir',
+      waktu: new Date().toISOString(),
+    });
+    setNama('');
+  };
+
+  if (!kelasAktif) return null;
+
+  return (
+    <Card className="p-4 space-y-4">
+      {qr && <img src={qr} alt="QR Absensi" className="w-40 h-40" />}
+      <div className="flex gap-2">
+        <Input value={nama} onChange={(e) => setNama(e.target.value)} placeholder="Nama siswa" />
+        <Button onClick={handleManual}>Absen Manual</Button>
+      </div>
+      <ul className="text-sm list-disc pl-4">
+        {absensiKelas.map((a) => (
+          <li key={a.id}>{a.siswaId} - {a.status}</li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default AbsensiQR;

--- a/src/components/DashboardUtama.tsx
+++ b/src/components/DashboardUtama.tsx
@@ -1,0 +1,24 @@
+import KelasSelector from './KelasSelector';
+import AbsensiQR from './AbsensiQR';
+import ExportData from './ExportData';
+import RingkasanKelas from './RingkasanKelas';
+import ManajemenSiswa from './ManajemenSiswa';
+import UploadProject from './UploadProject';
+import MateriMingguan from './MateriMingguan';
+
+const DashboardUtama = () => {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Dashboard Eskul Programming</h1>
+      <KelasSelector />
+      <RingkasanKelas />
+      <AbsensiQR />
+      <ManajemenSiswa />
+      <UploadProject />
+      <MateriMingguan />
+      <ExportData />
+    </div>
+  );
+};
+
+export default DashboardUtama;

--- a/src/components/ExportData.tsx
+++ b/src/components/ExportData.tsx
@@ -1,0 +1,19 @@
+import { Button } from './ui/button';
+import { useEskulStore } from '../stores/eskulStore';
+
+const ExportData = () => {
+  const kelasAktif = useEskulStore((s) => s.kelasAktif);
+  const exportKehadiran = useEskulStore((s) => s.exportKehadiran);
+  const exportNilai = useEskulStore((s) => s.exportNilai);
+
+  if (!kelasAktif) return null;
+
+  return (
+    <div className="flex gap-2">
+      <Button onClick={() => exportKehadiran(kelasAktif)}>Export Kehadiran</Button>
+      <Button onClick={() => exportNilai(kelasAktif)}>Export Nilai</Button>
+    </div>
+  );
+};
+
+export default ExportData;

--- a/src/components/KelasSelector.tsx
+++ b/src/components/KelasSelector.tsx
@@ -1,0 +1,25 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { KELAS_AKTIF, KELOMPOK_KELAS } from '../config/kelas';
+import { useEskulStore } from '../stores/eskulStore';
+
+const KelasSelector = () => {
+  const kelasAktif = useEskulStore((s) => s.kelasAktif);
+  const setKelasAktif = useEskulStore((s) => s.setKelasAktif);
+
+  return (
+    <Select value={kelasAktif} onValueChange={setKelasAktif}>
+      <SelectTrigger className="w-48">
+        <SelectValue placeholder="Pilih Kelas" />
+      </SelectTrigger>
+      <SelectContent>
+        {KELAS_AKTIF.map((k) => (
+          <SelectItem key={k} value={k}>
+            {KELOMPOK_KELAS[k].nama}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default KelasSelector;

--- a/src/components/ManajemenSiswa.tsx
+++ b/src/components/ManajemenSiswa.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Card } from './ui/card';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { useEskulStore } from '../stores/eskulStore';
+
+const ManajemenSiswa = () => {
+  const kelasAktif = useEskulStore((s) => s.kelasAktif);
+  const tambahSiswa = useEskulStore((s) => s.tambahSiswa);
+  const siswaKelas = useEskulStore((s) =>
+    Object.values(s.siswa).filter((si) => si.kelasId === kelasAktif)
+  );
+  const [nama, setNama] = useState('');
+  const [jurusan, setJurusan] = useState('');
+
+  const handleAdd = () => {
+    if (!nama || !kelasAktif) return;
+    tambahSiswa({
+      id: Date.now().toString(),
+      nama,
+      kelasId: kelasAktif,
+      jurusan,
+      nomorInduk: '',
+      aktif: true,
+    });
+    setNama('');
+    setJurusan('');
+  };
+
+  if (!kelasAktif) return null;
+
+  return (
+    <Card className="p-4 space-y-2">
+      <div className="flex gap-2">
+        <Input placeholder="Nama" value={nama} onChange={(e) => setNama(e.target.value)} />
+        <Input placeholder="Jurusan" value={jurusan} onChange={(e) => setJurusan(e.target.value)} />
+        <Button onClick={handleAdd}>Tambah</Button>
+      </div>
+      <ul className="text-sm list-disc pl-4">
+        {siswaKelas.map((s) => (
+          <li key={s.id}>{s.nama}</li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default ManajemenSiswa;

--- a/src/components/MateriMingguan.tsx
+++ b/src/components/MateriMingguan.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Card } from './ui/card';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { useEskulStore } from '../stores/eskulStore';
+
+const MateriMingguan = () => {
+  const kelasAktif = useEskulStore((s) => s.kelasAktif);
+  const tambahMateri = useEskulStore((s) => s.tambahMateri);
+  const materiKelas = useEskulStore((s) => s.materi[kelasAktif] || []);
+  const [judul, setJudul] = useState('');
+  const [link, setLink] = useState('');
+
+  const handleAdd = () => {
+    if (!kelasAktif || !judul) return;
+    tambahMateri({
+      id: Date.now().toString(),
+      kelasId: kelasAktif,
+      minggu: materiKelas.length + 1,
+      judul,
+      deskripsi: '',
+      linkVideo: link,
+    });
+    setJudul('');
+    setLink('');
+  };
+
+  if (!kelasAktif) return null;
+
+  return (
+    <Card className="p-4 space-y-2">
+      <div className="flex gap-2">
+        <Input placeholder="Judul" value={judul} onChange={(e) => setJudul(e.target.value)} />
+        <Input placeholder="Link" value={link} onChange={(e) => setLink(e.target.value)} />
+        <Button onClick={handleAdd}>Tambah</Button>
+      </div>
+      <ul className="text-sm list-disc pl-4">
+        {materiKelas.map((m) => (
+          <li key={m.id}>{m.minggu}. {m.judul}</li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default MateriMingguan;

--- a/src/components/RingkasanKelas.tsx
+++ b/src/components/RingkasanKelas.tsx
@@ -1,0 +1,22 @@
+import { Card } from './ui/card';
+import { useEskulStore } from '../stores/eskulStore';
+
+const RingkasanKelas = () => {
+  const kelasAktif = useEskulStore((s) => s.kelasAktif);
+  const siswa = useEskulStore((s) =>
+    Object.values(s.siswa).filter((si) => si.kelasId === kelasAktif)
+  );
+  const absensi = useEskulStore((s) => s.absensi[kelasAktif] || []);
+
+  if (!kelasAktif) return null;
+
+  return (
+    <Card className="p-4 space-y-1">
+      <p className="font-semibold">Ringkasan Kelas {kelasAktif}</p>
+      <p>Jumlah Siswa: {siswa.length}</p>
+      <p>Total Absensi: {absensi.length}</p>
+    </Card>
+  );
+};
+
+export default RingkasanKelas;

--- a/src/components/UploadProject.tsx
+++ b/src/components/UploadProject.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { Card } from './ui/card';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { useEskulStore } from '../stores/eskulStore';
+
+const UploadProject = () => {
+  const kelasAktif = useEskulStore((s) => s.kelasAktif);
+  const uploadProject = useEskulStore((s) => s.uploadProject);
+  const projectKelas = useEskulStore((s) => s.projects[kelasAktif] || []);
+  const [siswaId, setSiswaId] = useState('');
+  const [fileUrl, setFileUrl] = useState('');
+  const [nilai, setNilai] = useState('');
+
+  const handleAdd = () => {
+    if (!kelasAktif || !siswaId) return;
+    uploadProject({
+      id: Date.now().toString(),
+      siswaId,
+      kelasId: kelasAktif,
+      namaProject: siswaId,
+      fileUrl,
+      nilai: Number(nilai) || 0,
+      tanggalUpload: new Date().toISOString(),
+    });
+    setSiswaId('');
+    setFileUrl('');
+    setNilai('');
+  };
+
+  if (!kelasAktif) return null;
+
+  return (
+    <Card className="p-4 space-y-2">
+      <div className="flex flex-col md:flex-row gap-2">
+        <Input placeholder="Nama Siswa" value={siswaId} onChange={(e) => setSiswaId(e.target.value)} />
+        <Input placeholder="Link File" value={fileUrl} onChange={(e) => setFileUrl(e.target.value)} />
+        <Input type="number" placeholder="Nilai" value={nilai} onChange={(e) => setNilai(e.target.value)} />
+        <Button onClick={handleAdd}>Upload</Button>
+      </div>
+      <ul className="text-sm list-disc pl-4">
+        {projectKelas.map((p) => (
+          <li key={p.id}>{p.siswaId} - {p.nilai}</li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default UploadProject;

--- a/src/config/kelas.ts
+++ b/src/config/kelas.ts
@@ -1,0 +1,12 @@
+export const KELOMPOK_KELAS = {
+  'X-RPL-1': { nama: 'Kelas X RPL 1', kapasitas: 30 },
+  'X-RPL-2': { nama: 'Kelas X RPL 2', kapasitas: 30 },
+  'X-TKJ-1': { nama: 'Kelas X TKJ 1', kapasitas: 30 },
+  'X-TKJ-2': { nama: 'Kelas X TKJ 2', kapasitas: 30 },
+  'X-MM-1': { nama: 'Kelas X Multimedia 1', kapasitas: 30 },
+  'X-MM-2': { nama: 'Kelas X Multimedia 2', kapasitas: 30 },
+  'XI-RPL-1': { nama: 'Kelas XI RPL 1', kapasitas: 30 },
+  'XI-TKJ-1': { nama: 'Kelas XI TKJ 1', kapasitas: 30 },
+} as const;
+
+export const KELAS_AKTIF = Object.keys(KELOMPOK_KELAS) as Array<keyof typeof KELOMPOK_KELAS>;

--- a/src/hooks/useQRGenerator.ts
+++ b/src/hooks/useQRGenerator.ts
@@ -1,0 +1,10 @@
+import { useCallback } from 'react';
+import QRCode from 'qrcode';
+import type { QRData } from '../types/eskul.types';
+
+export const useQRGenerator = () => {
+  return useCallback(async (data: QRData) => {
+    const text = `${data.kelasId}|${data.tanggal}|${data.timestamp}`;
+    return QRCode.toDataURL(text);
+  }, []);
+};

--- a/src/stores/eskulStore.ts
+++ b/src/stores/eskulStore.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Absensi, Materi, Project, Siswa } from '../types/eskul.types';
+import { exportKehadiran, exportNilai } from '../utils/export';
+
+interface EskulState {
+  siswa: Record<string, Siswa>;
+  absensi: Record<string, Absensi[]>;
+  projects: Record<string, Project[]>;
+  materi: Record<string, Materi[]>;
+  kelasAktif: string;
+  setKelasAktif: (kelasId: string) => void;
+  tambahSiswa: (siswa: Siswa) => void;
+  absenSiswa: (absensi: Absensi) => void;
+  uploadProject: (project: Project) => void;
+  tambahMateri: (materi: Materi) => void;
+  exportKehadiran: (kelasId: string) => void;
+  exportNilai: (kelasId: string) => void;
+}
+
+export const useEskulStore = create<EskulState>()(
+  persist(
+    (set, get) => ({
+      siswa: {},
+      absensi: {},
+      projects: {},
+      materi: {},
+      kelasAktif: '',
+      setKelasAktif: (kelasId) => set({ kelasAktif: kelasId }),
+      tambahSiswa: (siswa) => set((state) => ({ siswa: { ...state.siswa, [siswa.id]: siswa } })),
+      absenSiswa: (absensi) => set((state) => ({
+        absensi: {
+          ...state.absensi,
+          [absensi.kelasId]: [...(state.absensi[absensi.kelasId] || []), absensi]
+        }
+      })),
+      uploadProject: (project) => set((state) => ({
+        projects: {
+          ...state.projects,
+          [project.kelasId]: [...(state.projects[project.kelasId] || []), project]
+        }
+      })),
+      tambahMateri: (materi) => set((state) => ({
+        materi: {
+          ...state.materi,
+          [materi.kelasId]: [...(state.materi[materi.kelasId] || []), materi]
+        }
+      })),
+      exportKehadiran: (kelasId) => {
+        const data = get().absensi[kelasId] || [];
+        exportKehadiran(kelasId, data);
+      },
+      exportNilai: (kelasId) => {
+        const data = get().projects[kelasId] || [];
+        exportNilai(kelasId, data);
+      },
+    }),
+    { name: 'dashboard-eskul-v1' }
+  )
+);

--- a/src/types/eskul.types.ts
+++ b/src/types/eskul.types.ts
@@ -1,0 +1,44 @@
+export interface Siswa {
+  id: string;
+  nama: string;
+  kelasId: string;
+  jurusan: string;
+  nomorInduk: string;
+  aktif: boolean;
+}
+
+export interface Absensi {
+  id: string;
+  siswaId: string;
+  kelasId: string;
+  tanggal: string;
+  status: 'hadir' | 'absen' | 'izin';
+  waktu: string;
+}
+
+export interface Project {
+  id: string;
+  siswaId: string;
+  kelasId: string;
+  namaProject: string;
+  fileUrl: string;
+  nilai: number;
+  tanggalUpload: string;
+}
+
+export interface Materi {
+  id: string;
+  kelasId: string;
+  minggu: number;
+  judul: string;
+  deskripsi: string;
+  linkVideo?: string;
+  filePath?: string;
+}
+
+export interface QRData {
+  kelasId: string;
+  tanggal: string;
+  timestamp: number;
+  type: 'absensi';
+}

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,16 @@
+import * as XLSX from 'xlsx';
+import type { Absensi, Project } from '../types/eskul.types';
+
+export const exportKehadiran = (kelasId: string, data: Absensi[]) => {
+  const worksheet = XLSX.utils.json_to_sheet(data);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Kehadiran');
+  XLSX.writeFile(workbook, `kehadiran-${kelasId}.xlsx`);
+};
+
+export const exportNilai = (kelasId: string, data: Project[]) => {
+  const worksheet = XLSX.utils.json_to_sheet(data);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Nilai');
+  XLSX.writeFile(workbook, `nilai-${kelasId}.xlsx`);
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,12 +21,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["src"],
-
-  "baseUrl": ".",
-  "paths": {
-    "@/*": ["./src/*"]
-  }
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add class configuration, types, Zustand store with localStorage persistence
- build QR attendance, project, material, and export components
- integrate dashboard with class selector and export to Excel

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components in shadcn ui)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6f46437a0832a827f3a5ab92b53a7